### PR TITLE
Fix no SNPs edge cases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: coalsimr
-Version: 0.0.9026
-Date: 2015-03-18
+Version: 0.0.9027
+Date: 2015-03-19
 License: GPL (>= 3)
 Title: Simulating the evolution of DNA sequences
 Author: Paul R. Staab

--- a/R/model.R
+++ b/R/model.R
@@ -134,7 +134,7 @@ has_inter_locus_var <- function(model) {
 
 
 has_trios <- function(model) {
-  sum(get_locus_length_matrix(model)[,-3]) > 0
+  sum(get_locus_length_matrix(model)[ , c(1:2, 4:5)]) > 0
 }
 
 

--- a/R/sumstat_ihh.R
+++ b/R/sumstat_ihh.R
@@ -29,6 +29,10 @@ SumstatIhh <- R6Class('sumstat_ihh', inherit = Sumstat, #nolint
       ind <- get_population_indiviuals(model, private$population)
       lapply(1:length(seg_sites), function(locus) {
         assert_that(is.matrix(seg_sites[[locus]]))
+        if (ncol(seg_sites[[locus]]) == 0) {
+          return(matrix(0, 2, 0, dimnames = list(c("Anc. Allele",
+                                                   "Der. Allele"), NULL)))
+        }
         snps <- private$get_snp(pos[[locus]], locus, model)
         ehh <- sapply(snps, function(snp) {
           rehh::calc_ehh(self$segsites_to_rehh_data(seg_sites[[locus]],

--- a/R/sumstat_seg_sites.R
+++ b/R/sumstat_seg_sites.R
@@ -25,7 +25,8 @@ conv_for_trios <- function(seg_sites, llm) {
     left <- pos < borders[1]
     middle <- pos >= borders[2] & pos < borders[3]
     right <- pos >= borders[4]
-    seg_sites[[i]] <- seg_sites[[i]][ , left | middle | right, drop=FALSE]
+    seg_sites[[i]] <- seg_sites[[i]][, left | middle | right, drop=FALSE]
+    assert_that(nrow(seg_sites[[i]]) > 0)
 
     pos[left] <- pos[left] * total_length / llm[i, 1]
     pos[middle] <- (pos[middle] - borders[2]) * total_length / llm[i, 3]

--- a/src/parse_ms_output.cpp
+++ b/src/parse_ms_output.cpp
@@ -59,7 +59,7 @@ List parse_ms_output(const List file_names,
       else if (line.substr(0, 9) == "segsites:") {
 
         if (line.substr(0, 11) == "segsites: 0") {
-          NumericMatrix ss = NumericMatrix(0, 0);
+          NumericMatrix ss = NumericMatrix(individuals, 0);
           ss.attr("positions") = NumericVector(0);
           seg_sites[locus] = ss;
         } else {

--- a/src/sum_stat_jsfs.cpp
+++ b/src/sum_stat_jsfs.cpp
@@ -29,9 +29,10 @@ NumericMatrix calc_jsfs(const List seg_sites,
 
   for (int locus = 0; locus < seg_sites.size(); ++locus) {
     ss = as<NumericMatrix>(seg_sites[locus]);
+    ncol = ss.ncol();
+    if (ncol == 0) continue;
     if (ss.nrow() < nrows_required) stop("Seg. Sites has too few rows.");
     trio_locus = getTrioLocus(ss);
-    ncol = ss.ncol();
 
     for (int j = 0; j < ncol; ++j) {
       if (trio_locus(j) != 0) continue; // Only calculate for middle locus

--- a/tests/testthat/test-model-class.R
+++ b/tests/testthat/test-model-class.R
@@ -261,3 +261,10 @@ test_that('getting model command works', {
   expect_that(cmd, is_a("character"))
   expect_true(all(nchar(cmd) > 0))
 })
+
+
+test_that("has_trios works", {
+  expect_false(has_trios(model_theta_tau()))
+  expect_false(has_trios(model_f84()))
+  expect_true(has_trios(model_trios()))
+})

--- a/tests/testthat/test-sumstat-iHH.R
+++ b/tests/testthat/test-sumstat-iHH.R
@@ -59,3 +59,18 @@ test_that('ihh works with trios', {
   expect_that(stat, is_a('list'))
   expect_equal(length(stat), 1)
 })
+
+
+test_that("ihh works with empty segsites", {
+  model <- model_trios()
+  seg_sites <- list(matrix(0, 5, 0))
+  ihh <- sumstat_ihh(population = 1)
+  attr(seg_sites[[1]], "positions") <- numeric(0)
+  stat <- ihh$calculate(seg_sites, NULL, model)
+  expect_equivalent(stat, list(matrix(0, 2, 0)))
+
+  seg_sites <- list(matrix(0, 0, 0))
+  attr(seg_sites[[1]], "positions") <- numeric(0)
+  stat <- ihh$calculate(seg_sites, NULL, model)
+  expect_equivalent(stat, list(matrix(0, 2, 0)))
+})

--- a/tests/testthat/test-sumstat-jsfs.R
+++ b/tests/testthat/test-sumstat-jsfs.R
@@ -57,6 +57,12 @@ test_that("calculation of the JSFS is correct", {
     expect_equal(jsfs[3, 3], 4)
     expect_equal(jsfs[1, 3], 1)
     expect_equal(jsfs[3, 1], 1)
+
+    # No SNPs edgecase
+    jsfs <- calc_jsfs(list(matrix(0, 4, 0)), 1:2, 3:4)
+    expect_equal(jsfs, matrix(0, 3, 3))
+    jsfs <- calc_jsfs(list(matrix(0, 0, 0)), 1:2, 3:4)
+    expect_equal(jsfs, matrix(0, 3, 3))
 })
 
 


### PR DESCRIPTION
* Fixes calculation of jsfs and ihh when there are no SNPs on a simulated locus
* Fixes a big in the calculation of `has_trios`